### PR TITLE
added aggregatelist argument to thief, tsaggregates, and reconcile functions

### DIFF
--- a/R/combine.R
+++ b/R/combine.R
@@ -23,6 +23,7 @@
 #' is not needed. However, it will be used if not \code{NULL}.
 #' @param returnall If \code{TRUE}, a list of time series corresponding to the first argument
 #' is returned, but now reconciled. Otherwise, only the most disaggregated series is returned.
+#' @param aggregatelist (optional) User-selected list of forecast aggregates to consider
 #'
 #' @return
 #'   List of reconciled forecasts in the same format as \code{forecast}.
@@ -54,7 +55,8 @@
 
 reconcilethief <- function(forecasts,
                comb=c("struc","mse","ols","bu","shr","sam"),
-               mse=NULL, residuals=NULL, returnall=TRUE)
+               mse=NULL, residuals=NULL, returnall=TRUE, 
+               aggregatelist=NULL)
 {
   comb <- match.arg(comb)
 
@@ -108,7 +110,8 @@ reconcilethief <- function(forecasts,
   else
   {
     # Set up group matrix for hts
-    nsum <- rep(freq,m/freq)
+    # (adjusted to allow consideration of aggregatelist input)
+    nsum <- rev(rep(m/freq, freq))
     unsum <- unique(nsum)
     grps <- matrix(0, nrow=length(unsum)-1, ncol=m)
     for(i in 1:(length(unsum)-1))
@@ -156,7 +159,7 @@ reconcilethief <- function(forecasts,
     if(!returnall)
       return(bts)
     else
-      return(tsaggregates(bts))
+      return(tsaggregates(bts, aggregatelist=aggregatelist))
   }
   else #return forecast objects
   {
@@ -173,7 +176,7 @@ reconcilethief <- function(forecasts,
     }
     else
     {
-      allts <- tsaggregates(bts)
+      allts <- tsaggregates(bts, aggregatelist=aggregatelist)
       for(i in seq_along(origf))
       {
         adj <- allts[[i]] - origf[[i]]$mean

--- a/R/tsaggregates.R
+++ b/R/tsaggregates.R
@@ -7,6 +7,7 @@
 #' @param align Indicates how the aggregates are to be aligned:
 #' either with the \code{start} of the series or the \code{end} of the series.
 #' For forecasting purposes, it should be set to \code{end}.
+#' @param aggregatelist User-selected list of aggregates to consider.
 #'
 #' @return A list of time series. The first element is the series `y`,
 #' followed by series with increasing levels of aggregation. The last
@@ -20,7 +21,8 @@
 #' @export
 
 
-tsaggregates <- function (y, m=frequency(y), align=c("end","start"))
+tsaggregates <- function (y, m=frequency(y), align=c("end","start"),
+                          aggregatelist=NULL)
 {
   align <- match.arg(align)
   n <- length(y)
@@ -32,6 +34,13 @@ tsaggregates <- function (y, m=frequency(y), align=c("end","start"))
   mout <- mout[mout <= n]
   if (length(mout) == 0L)
     stop("Series too short for aggregation")
+  
+  # If user has specified aggregatelist, then consider only those aggregates
+  if (!is.null(aggregatelist))
+    mout <- mout[mout %in% aggregatelist]
+  if (length(mout) == 0L)
+    stop("No valid factors in aggregatelist argument")
+  
   k <- length(mout)
   y.out <- vector("list",k)
   y.out[[1L]] <- y


### PR DESCRIPTION
Prof. Hyndman, first of all I'm a big fan of much of your work, especially the `forecast` package in R. I recently came across `thief` and the associated working paper, and I'm very interested in the temporal hierarchies approach proposed.

In the application in which I'm exploring the use of `thief`, I wanted to be able to control which aggregates were considered (i.e. forecast and then reconciled), rather than just using all factors of `m`. I thought I would share in case of wider interest.

This pull request enables this functionality by including an additional optional argument `aggregatelist` to the functions `reconcilethief`, `tsaggregates`, and `thief`. I have done some basic testing (i.e. confirming that the example:

`fc <- thief(USAccDeaths)`

Returns the same when passed an `aggregatelist` arguments with all factors:

`fc <- thief(USAccDeaths, aggregatelist=c(1,2,3,4,6,12))`

But I'm not a particularly experienced user of R, so might be worth doing some sanity checking of your own, if you are going to adopt the changes. Thanks so much for making your software available open source!

- Khalid.
